### PR TITLE
Dev/fail fast false

### DIFF
--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -18,8 +18,9 @@ jobs:
   bump_version:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' , '3.11']
+        python-version: [ '3.8', '3.9', '3.10' ]
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"


### PR DESCRIPTION
remedy issue #33 
Note: build process is broken for py3.11. The scope of the effort to fix this is unknown. Hopefully, the updated cmake can resolve the problem. In the meantime, allow other python versions to complete the build and release.